### PR TITLE
Coincident space-time points: code error & methodological point

### DIFF
--- a/R/STIKhat.R
+++ b/R/STIKhat.R
@@ -14,12 +14,20 @@ STIKhat <- function(xyt, s.region, t.region, dist, times, lambda, correction = "
   correc2 = rep(0,5)
   correc2[id] = 1	
   
-  dup <- duplicated(data.frame(xyt[,1], xyt[,2], xyt[,3]), fromLast = TRUE)[1]
+  dup <- any(duplicated(data.frame(xyt[,1], xyt[,2], xyt[,3])))
   if (dup == TRUE){
-    messnbd <- paste("space-time data contain duplicated points")
+    messnbd <- paste("Space-time data contains duplicated points")
     warning(messnbd,call. = FALSE)
   }
-
+	
+	if(!missing(lambda)){
+		dup1 <- any(duplicated(data.frame(xyt[,1], xyt[,2])))
+		if (dup1 == TRUE){
+			messnbd1 <- paste("xyt has spatially-coincident points. This is OK for STIKhat() computation but you should take care in the methods you used for estimating the spatial intensity in the 'lambda' term.")
+			warning(messnbd1,call. = FALSE)
+		}    
+	}
+	
   if (missing(s.region)) s.region <- sbox(xyt[,1:2], xfrac=0.01, yfrac=0.01)
   if (missing(t.region)){
       xr = range(xyt[,3], na.rm = TRUE)


### PR DESCRIPTION
I am very glad you started this package, thank you @edit318 et al! I stumbled upon some findings when tinkering.

Code error: using the first entry of ```duplicated()```, i.e. ```duplicated(...)[1]``` will only capture duplicated points when one of the n-plicates is across xyt[1,]. Using ```any()``` solves this.

Methodological: Although it is space-time coincidence which breaks ```STIKhat()```(cf *Gabriel & Diggle 2009*), it would be useful to warn of the weaker version of space-time points being spatially coincident. This is of relevance for users computing the spatial intensity in other packages for ```mhat``` in the ```lambda = ...``` argument of your function. Furthermore as your ```STIKhat.Rd``` example uses *Berman & Diggle*'s method to find the bandwidth (```splancs::kernel2d```), it is likely a novice (like myself) will follow suit (as I did) and get an incorrect bandwidth ```h``` back from that third-party function to use in yours---I had problems with spatially-coincident data with ```kernel2d()``` which causes the MSE(h) profile to lose its convex shape, leading to a minimal h that matches the smallest h-step (making the h step smaller just makes the minimal h reduce too, so h tends to zero).